### PR TITLE
Remove unused LovyanGFX dependency

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -20,7 +20,6 @@ idf_component_register(
         esp_lcd
         esp_lvgl_port
         lvgl
-        LovyanGFX
         esp_lcd_touch
         esp_lcd_touch_gt911
         fatfs

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -4,4 +4,3 @@ dependencies:
   espressif/esp_lvgl_port: "^2.6.1"
   espressif/esp_lcd_touch: "^1.1.2"
   espressif/esp_lcd_touch_gt911: "^1.1.3"
-  lovyan03/LovyanGFX: "^1.1.9"


### PR DESCRIPTION
## Summary
- remove the LovyanGFX component requirement from the main component manifest
- drop the LovyanGFX entry from the component's CMake registration because it is unused

## Testing
- not run (ESP-IDF tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf9b3382b883239e8705a7d4de1c96