### PR TITLE
Fix lvgl fatfs dependency linkage

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -34,3 +34,14 @@ idf_component_register(
         esp_netif
         tjpgd
 )
+
+# Workaround for ESP-IDF v5.5 LVGL component missing the FATFS dependency
+# declaration. Without this adjustment, lv_fs_fatfs.c fails to compile due to
+# the ff.h header not being discoverable when the LVGL component is built.
+# Inject the dependency link here until the upstream component definition is
+# fixed.
+idf_component_get_property(lvgl_lib lvgl COMPONENT_LIB)
+idf_component_get_property(fatfs_lib fatfs COMPONENT_LIB)
+if(TARGET ${lvgl_lib} AND TARGET ${fatfs_lib})
+    target_link_libraries(${lvgl_lib} PRIVATE ${fatfs_lib})
+endif()


### PR DESCRIPTION
## Summary
- add a local workaround so the LVGL component explicitly links against FATFS until Espressif fixes the upstream dependency declaration

## Testing
- not run (ESP-IDF toolchain not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cfdf87515883239212a3665f689770