### PR TITLE
Fix LVGL FATFS drive configuration for ESP-IDF v5.5

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -50,4 +50,11 @@ if(TARGET ${lvgl_lib} AND TARGET ${fatfs_lib})
         PUBLIC
         $<TARGET_PROPERTY:${fatfs_lib},INTERFACE_INCLUDE_DIRECTORIES>
     )
+    target_compile_definitions(
+        ${lvgl_lib}
+        PUBLIC
+            LV_USE_FS_FATFS=1
+            LV_FS_FATFS_LETTER='0'
+            LV_FS_FATFS_PATH="/sdcard"
+    )
 endif()


### PR DESCRIPTION
## Summary
- propagate FATFS interface directories and compile-time definitions into the lvgl component
- configure LVGL to force FATFS support and explicitly select the '/sdcard' VFS drive letter used by the project

## Testing
- not run (ESP-IDF toolchain is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cfeceebe6c83239db4b69ea8504969