### PR TITLE
Handle TinyUSB CDC callback registration errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # jpg
+
+## Initialisation USB CDC
+
+La fonction `comm_usb_init()` installe le pilote TinyUSB, enregistre le callback de réception CDC puis initialise le port. Si l'enregistrement du callback échoue, l'initialisation est interrompue et deux traces d'erreur apparaissent dans le journal :
+
+1. `Failed to register CDC RX callback: <esp_err_name>` pour fournir la cause exacte remontée par `tinyusb_cdcacm_register_callback()`.
+2. `cdc cb failed` (via `ESP_RETURN_ON_ERROR`) indiquant que l'initialisation du canal série USB s'est arrêtée.
+
+Dans ce cas, vérifier la configuration TinyUSB (alim, câblage USB, enumération hôte) avant de relancer le firmware.

--- a/main/comm_usb.c
+++ b/main/comm_usb.c
@@ -1,5 +1,6 @@
 #include "comm_usb.h"
 #include <string.h>
+#include "esp_err.h"
 #include "esp_log.h"
 #include "tinyusb.h"
 #include "tusb_cdc_acm.h"
@@ -43,7 +44,11 @@ esp_err_t comm_usb_init(comm_usb_rx_cb_t rx_cb, void *ctx)
     };
     ESP_RETURN_ON_ERROR(tinyusb_driver_install(&tusb_cfg), TAG, "tinyusb install failed");
 
-    tinyusb_cdcacm_register_callback(s_cdc_itf, CDCACM_EVENT_RX, cdc_rx_callback);
+    esp_err_t ret = tinyusb_cdcacm_register_callback(s_cdc_itf, CDCACM_EVENT_RX, cdc_rx_callback);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to register CDC RX callback: %s", esp_err_to_name(ret));
+    }
+    ESP_RETURN_ON_ERROR(ret, TAG, "cdc cb failed");
     tinyusb_cdcacm_init_config_t cdc_cfg = {
         .usb_dev = TINYUSB_USBDEV_0,
         .cdc_port = s_cdc_itf,


### PR DESCRIPTION
## Summary
- verify the return code from `tinyusb_cdcacm_register_callback` and bail out via `ESP_RETURN_ON_ERROR` when it fails
- log the TinyUSB error name before returning so the root cause is exposed in the console
- document the USB CDC callback failure scenario in the README for easier troubleshooting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d066bd495c8323badd0f5ab1b3c9ac